### PR TITLE
Support for asProduct10 .. asProduct22

### DIFF
--- a/src/main/scala/sjson/json/Generic.scala
+++ b/src/main/scala/sjson/json/Generic.scala
@@ -47,7 +47,7 @@ trait Generic extends Protocol {
   }
 
 
-  <#list 2..9 as i> 
+  <#list 2..22 as i> 
   <#assign typeParams><#list 1..i as j>T${j}<#if i !=j>,</#if></#list></#assign>
 
   def asProduct${i}[S, ${typeParams}](<#list 1..i as j>f${j}: String<#if i != j>,</#if></#list>)(apply : (${typeParams}) => S)(unapply : S => Product${i}[${typeParams}])(implicit <#list 1..i as j>bin${j}: Format[T${j}]<#if i != j>,</#if></#list>) = new Format[S]{


### PR DESCRIPTION
I don't think it needs a big explanation. There are case classes that have 10..22 arguments. I need support for those as well.
